### PR TITLE
Added double click emulation for tablets in project tree.

### DIFF
--- a/codenvy-gwt-client-commons/src/main/java/com/codenvy/ide/util/browser/BrowserUtils.java
+++ b/codenvy-gwt-client-commons/src/main/java/com/codenvy/ide/util/browser/BrowserUtils.java
@@ -54,6 +54,18 @@ public abstract class BrowserUtils {
         return Window.Navigator.getUserAgent().contains(" CrOS ");
     }
 
+    public static boolean isIPad() {
+        return Window.Navigator.getAppVersion().contains("iPad");
+    }
+
+    public static boolean isIphone() {
+        return Window.Navigator.getAppVersion().contains("iPhone");
+    }
+
+    public static boolean isAndroid() {
+        return Window.Navigator.getAppVersion().contains("Android");
+    }
+
     public static boolean hasUrlParameter(String parameter) {
         return Window.Location.getParameter(parameter) != null;
     }


### PR DESCRIPTION
Tablets not allow double click. They interpret double click like two single clicks. So we can't open files in project tree by double click in tablets. In this commit added double click emulation for tablets in project tree for support opening files in tablets.
